### PR TITLE
fix: Solve the error of array const in Support/Setting class.

### DIFF
--- a/app/Support/Settings.php
+++ b/app/Support/Settings.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\App;
 
 final class Settings
 {
-    private const array TAGS = ['Eloquent', 'Blade', 'Migrations', 'Seeding', 'Routing', 'Controllers', 'Middleware', 'Requests', 'Responses', 'Views', 'Forms', 'Validation', 'Mail', 'Notifications'];
+    private const TAGS = ['Eloquent', 'Blade', 'Migrations', 'Seeding', 'Routing', 'Controllers', 'Middleware', 'Requests', 'Responses', 'Views', 'Forms', 'Validation', 'Mail', 'Notifications'];
 
-    private const array LOCALES = [
+    private const LOCALES = [
         'en' => 'English',
         'fr' => 'French',
         'ar' => 'Arabic',


### PR DESCRIPTION
There was the error in Setting class for defining the array const in the **PHP8.2** version

It will work in the **php8.3** but will give error in the **php8.2** version

Error cause : The error encountering is due to the way  trying to declare the constant arrays in PHP. The correct syntax for defining class constants does not allow specifying the type (array) in the constant declaration.

OLD ERROR PICTURE :

![Screenshot from 2024-08-13 11-03-43](https://github.com/user-attachments/assets/deaa68d5-1895-4b9f-8e56-bec4dbd778db)

SOLVE ERROR PICTURE :

![Screenshot from 2024-08-13 11-05-29](https://github.com/user-attachments/assets/b7c20f30-39b1-4f51-8013-2b8b94386f1e)

