### PR TITLE
Fix command typo in README for running type coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Follow these steps to set up a development environment:
     composer test:types
 
     # Run type coverage
-    composer test:types-coverage
+    composer test:type-coverage
 
     # Run the test suite
     composer test:unit


### PR DESCRIPTION
- Corrected the command to run type coverage in the README.md file.

- Changed composer test:types-coverage to composer test:type-coverage.

- This fix ensures users can successfully run the test command as intended.