### PR TITLE
Feat: remove make from url macro

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Support\FileUploaderFromUrl;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\ServiceProvider;
 use Override;
 
@@ -18,5 +20,8 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void {}
+    public function boot(): void
+    {
+        UploadedFile::macro('makeFromUrl', fn (string $url): ?UploadedFile => (new FileUploaderFromUrl)($url));
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Override;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,32 +18,5 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
-    {
-        // @codeCoverageIgnoreStart
-        UploadedFile::macro('makeFromUrl', function (string $url): ?UploadedFile {
-            $tempFile = tempnam(sys_get_temp_dir(), Str::random(32));
-
-            if ($tempFile === false) {
-                return null;
-            }
-
-            $file = file_get_contents($url);
-
-            if ($file === false) {
-                return null;
-            }
-
-            file_put_contents($tempFile, $file);
-
-            return new UploadedFile(
-                $tempFile,
-                basename($url),
-                mime_content_type($tempFile) ?: null,
-                null,
-                true
-            );
-        });
-        // @codeCoverageIgnoreEnd
-    }
+    public function boot(): void {}
 }

--- a/app/Support/FileUploaderFromUrl.php
+++ b/app/Support/FileUploaderFromUrl.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class FileUploaderFromUrl
+{
+    public function __invoke(string $url): ?UploadedFile
+    {
+        $response = Http::get($url);
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        $tempFile = $this->tempnam(sys_get_temp_dir(), Str::random(32));
+
+        if ($tempFile === false) {
+            return null;
+        }
+
+        file_put_contents($tempFile, $response->body());
+
+        return new UploadedFile(
+            $tempFile,
+            basename($url),
+            $response->header('Content-Type') ?: null,
+            null,
+            true
+        );
+    }
+
+    public function tempnam(string $dir, string $prefix): string|false
+    {
+        return tempnam($dir, $prefix);
+    }
+}

--- a/app/Traits/HasFileFromUrl.php
+++ b/app/Traits/HasFileFromUrl.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
-use App\Support\FileUploaderFromUrl;
 use Illuminate\Http\UploadedFile;
 
+/**
+ * @mixin \Illuminate\Foundation\Http\FormRequest
+ */
 trait HasFileFromUrl
 {
     public function resolveFileFromUrl(string $field): void
     {
         if (! $this->hasFile($field) && filter_var($this->get($field), FILTER_VALIDATE_URL)) {
-            $file = (new FileUploaderFromUrl)(
+            $file = UploadedFile::makeFromUrl(
                 (string) $this->string($field)
             );
 

--- a/app/Traits/HasFileFromUrl.php
+++ b/app/Traits/HasFileFromUrl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
+use App\Support\FileUploaderFromUrl;
 use Illuminate\Http\UploadedFile;
 
 trait HasFileFromUrl
@@ -11,11 +12,11 @@ trait HasFileFromUrl
     public function resolveFileFromUrl(string $field): void
     {
         if (! $this->hasFile($field) && filter_var($this->get($field), FILTER_VALIDATE_URL)) {
-            $file = UploadedFile::makeFromUrl(
+            $file = (new FileUploaderFromUrl)(
                 (string) $this->string($field)
             );
 
-            if ($file !== null) {
+            if ($file instanceof UploadedFile) {
                 $this->merge([
                     $field => $file,
                 ]);

--- a/tests/Unit/Support/FileUploaderFromUrlTest.php
+++ b/tests/Unit/Support/FileUploaderFromUrlTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\FileUploaderFromUrl;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+
+test('invoke returns uploaded file', function () {
+    Http::fake([
+        'example.com/*' => Http::response('file content', 200, ['Content-Type' => 'text/plain']),
+    ]);
+
+    $uploader = new FileUploaderFromUrl;
+    $uploadedFile = $uploader('http://example.com/file.txt');
+
+    expect($uploadedFile)->toBeInstanceOf(UploadedFile::class);
+    expect($uploadedFile->getClientOriginalName())->toBe('file.txt');
+    expect($uploadedFile->getClientMimeType())->toBe('text/plain');
+    expect(file_get_contents($uploadedFile->getPathname()))->toBe('file content');
+});
+
+test('invoke returns null on failed request', function () {
+    Http::fake([
+        'example.com/*' => Http::response('Not Found', 404),
+    ]);
+
+    $uploader = new FileUploaderFromUrl;
+    $uploadedFile = $uploader('http://example.com/file.txt');
+
+    expect($uploadedFile)->toBeNull();
+});
+
+test('invoke returns null on temp file creation failure', function () {
+    Http::fake([
+        'example.com/*' => Http::response('file content', 200, ['Content-Type' => 'text/plain']),
+    ]);
+
+    $uploader = $this->partialMock(FileUploaderFromUrl::class, function ($mock) {
+        $mock->shouldReceive('tempnam')->andReturn(false);
+    });
+
+    $uploadedFile = $uploader('http://example.com/file.txt');
+
+    expect($uploadedFile)->toBeNull();
+});


### PR DESCRIPTION
This pull request refactors the file uploading functionality from a URL, moving the logic from `AppServiceProvider` to a dedicated class and updating the relevant trait and tests accordingly. The most important changes include the creation of a new support class for file uploading, the removal of the previous macro, and the addition of unit tests for the new class.

Macro stuff was not testable in this case!