### PR TITLE
Adding Post Status Feature (Draft/Published)

### DIFF
--- a/app/Enums/PostStatus.php
+++ b/app/Enums/PostStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PostStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => __('posts.status.Draft'),
+            self::Published => __('posts.status.Published'),
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Draft => 'bg-yellow-500',
+            self::Published => 'bg-green-500',
+        };
+    }
+
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Draft => 'yellow',
+            self::Published => 'green',
+        };
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -13,6 +13,7 @@ use App\Models\Category;
 use App\Models\Post;
 use App\Support\QueryResolver;
 use App\Support\Settings;
+use App\Enums\PostStatus;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -44,6 +45,7 @@ final class PostController
         return view('posts.create', [
             'categories' => Category::query()->pluck('title', 'id'),
             'tags' => Settings::getTags(),
+            'statuses' => PostStatus::cases(),
         ]);
     }
 
@@ -77,6 +79,7 @@ final class PostController
             'post' => $post,
             'categories' => Category::query()->pluck('title', 'id'),
             'tags' => Settings::getTags(),
+            'statuses' => PostStatus::cases(),
         ]);
     }
 

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Enums\PostStatus;
 use App\Traits\HasFileFromUrl;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
 use Override;
 
 final class StorePostRequest extends FormRequest
@@ -35,6 +37,7 @@ final class StorePostRequest extends FormRequest
             'image' => ['required', 'image'],
             'content' => ['required'],
             'published_at' => ['nullable', 'date'],
+            'status' => ['required', 'string', new Enum(PostStatus::class)],
             'category_id' => [
                 'required',
                 'exists:categories,id',

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -18,6 +18,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Mews\Purifier\Casts\CleanHtmlInput;
+use App\Enums\PostStatus;
 use Override;
 
 /**
@@ -30,6 +31,7 @@ use Override;
  * @property UploadedFile|string|null $image
  * @property string $content
  * @property Carbon|null $published_at
+ * @property PostStatus $status
  * @property int $category_id
  * @property array<string>|null $tags
  * @property FeaturedStatus $is_featured
@@ -48,6 +50,7 @@ use Override;
     'image',
     'content',
     'published_at',
+    'status',
     'category_id',
     'tags',
     'is_featured',
@@ -125,6 +128,7 @@ final class Post extends Model
             'published_at' => 'datetime',
             'is_featured' => FeaturedStatus::class,
             'content' => CleanHtmlInput::class,
+            'status' => PostStatus::class,
         ];
     }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -30,6 +30,7 @@ final class PostFactory extends Factory
             'image' => $this->fakeImageUrl(),
             'content' => $this->faker->randomHtml(),
             'published_at' => $this->faker->dateTimeBetween('-1 month', '+3 months'),
+            'status' => $this->faker->randomElement(array_column(PostStatus::cases(), 'value')),
             'category_id' => CategoryFactory::new(),
             'tags' => $this->faker->randomElements(['Eloquent', 'Blade', 'Migrations', 'Seeding', 'Routing', 'Controllers', 'Middleware', 'Requests', 'Responses', 'Views', 'Forms', 'Validation', 'Mail', 'Notifications'], $this->faker->numberBetween(1, 3)),
             'is_featured' => $this->faker->randomElement(array_column(FeaturedStatus::cases(), 'value')),

--- a/database/migrations/2026_05_06_171934_add_status_to_posts_table.php
+++ b/database/migrations/2026_05_06_171934_add_status_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->string('status')->default('draft')->after('published_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // did not prefer to add down method, I just add another migration if i want to rollback
+    }
+};

--- a/lang/ar/posts.php
+++ b/lang/ar/posts.php
@@ -10,6 +10,8 @@ return [
         'Image' => 'الصورة',
         'Category' => 'التصنيف',
         'Select a Category' => 'اختر التصنيف',
+        'Status' => 'الحالة',
+        'Select a Status' => 'اختر الحالة',
         'Description' => 'الوصف',
         'Tags' => 'الوسوم',
         'Featured' => 'مميز',
@@ -28,6 +30,10 @@ return [
         'Edit Post' => 'تعديل المقال',
         'Update Post' => 'تعديل المقال',
         'Cancel' => 'إلغاء',
+    ],
+    'status' => [
+        'Draft' => 'مسودة',
+        'Published' => 'منشور',
     ],
     'show' => [
         'Not Featured' => 'غير مميز',

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -10,6 +10,8 @@ return [
         'Image' => 'Image',
         'Category' => 'Category',
         'Select a Category' => 'Select a Category',
+        'Status' => 'Status',
+        'Select a Status' => 'Select a Status',
         'Description' => 'Description',
         'Tags' => 'Tags',
         'Featured' => 'Featured',
@@ -28,6 +30,10 @@ return [
         'Edit Post' => 'Edit Post',
         'Update Post' => 'Update Post',
         'Cancel' => 'Cancel',
+    ],
+    'status' => [
+        'Draft' => 'Draft',
+        'Published' => 'Published',
     ],
     'show' => [
         'Not Featured' => 'Not Featured',

--- a/lang/fr/posts.php
+++ b/lang/fr/posts.php
@@ -10,6 +10,8 @@ return [
         'Image' => 'Image',
         'Category' => 'Catégorie',
         'Select a Category' => 'Sélectionnez une catégorie',
+        'Status' => 'Statut',
+        'Select a Status' => 'Sélectionnez un statut',
         'Description' => 'Description',
         'Tags' => 'Tags',
         'Featured' => 'En vedette',
@@ -28,6 +30,10 @@ return [
         'Edit Post' => 'Modifier l\'article',
         'Update Post' => 'Mettre à jour l\'article',
         'Cancel' => 'Annuler',
+    ],
+    'status' => [
+        'Draft' => 'Brouillon',
+        'Published' => 'Publié',
     ],
     'show' => [
         'Not Featured' => 'Pas en vedette',

--- a/lang/gu/posts.php
+++ b/lang/gu/posts.php
@@ -11,6 +11,8 @@ return [
         'Image' => 'છબી',
         'Category' => 'વર્ગ',
         'Select a Category' => 'એક વર્ગ પસંદ કરો',
+        'Status' => 'સ્થિતિ',
+        'Select a Status' => 'એક સ્થિતિ પસંદ કરો',
         'Description' => 'વર્ણન',
         'Tags' => 'ટેગ્સ',
         'Featured' => 'ફિચર્ડ',
@@ -29,6 +31,10 @@ return [
         'Edit Post' => 'પોસ્ટ સંપાદિત કરો',
         'Update Post' => 'પોસ્ટ અપડેટ કરો',
         'Cancel' => 'રદ કરો',
+    ],
+    'status' => [
+        'Draft' => 'ડ્રાફ્ટ',
+        'Published' => 'પ્રકાશિત',
     ],
     'show' => [
         'Not Featured' => 'ફિચર્ડ નથી',

--- a/lang/hi/posts.php
+++ b/lang/hi/posts.php
@@ -29,6 +29,10 @@ return [
         'Update Post' => 'पोस्ट अपडेट करें',
         'Cancel' => 'रद करना',
     ],
+    'status' => [
+        'Draft' => 'मसौदा',
+        'Published' => 'प्रकाशित',
+    ],
     'show' => [
         'Not Featured' => 'विशेष रुप से प्रदर्शित नहीं',
         'Featured' => 'विशेष रुप से प्रदर्शित',
@@ -50,5 +54,7 @@ return [
         'Post deleted successfully' => 'पोस्ट सफलतापूर्वक हटा दी गई।',
         'Post featured successfully' => 'पोस्ट सफलतापूर्वक विशेष रुप से प्रदर्शित की गई।',
         'Post unfeatured successfully' => 'पोस्ट सफलतापूर्वक विशेष रुप से प्रदर्शित नहीं की गई।',
+    ],
+];
     ],
 ];

--- a/resources/views/posts/_form.blade.php
+++ b/resources/views/posts/_form.blade.php
@@ -62,6 +62,20 @@
 
             <div class="mt-6 space-y-5">
                 <x-field>
+                    <x-label for="status">{{ __('posts.form.Status') }}</x-label>
+                    <x-select id="status" name="status">
+                        <option value="">{{ __('posts.form.Select a Status') }}</option>
+                        @foreach ($statuses as $status)
+                            <option value="{{ $status->value }}" @selected(old('status', $post->status?->value ?? null) == $status->value)>
+                                {{ $status->label() }}
+                            </option>
+                        @endforeach
+                    </x-select>
+                    @error('status')
+                        <x-error-message>{{ $message }}</x-error-message>
+                    @enderror
+                </x-field>
+                <x-field>
                     <x-label for="category_id">{{ __('posts.form.Category') }}</x-label>
                     <x-select id="category_id" name="category_id">
                         <option value="">{{ __('posts.form.Select a Category') }}</option>

--- a/tests/Feature/Http/Controllers/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/PostControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\PostStatus;
 use App\Models\Category;
 use App\Models\Post;
 use Illuminate\Http\UploadedFile;
@@ -111,6 +112,7 @@ test('can see create post page', function (): void {
         ->assertViewHasAll([
             'categories',
             'tags',
+            'statuses',
         ]);
 });
 
@@ -125,6 +127,7 @@ test('can create post', function (): void {
         'category_id' => $category->id,
         'description' => 'this is the description',
         'content' => 'this is the content',
+        'status' => PostStatus::Draft->value,
         'tags' => ['Eloquent'],
     ])
         ->assertRedirect(route('posts.index', ['published' => true]))
@@ -144,6 +147,7 @@ test('cannot create post with invalid data', function (): void {
             'category_id',
             'description',
             'content',
+            'status',
         ]);
 });
 
@@ -168,6 +172,7 @@ test('can see edit post page', function (): void {
             'post',
             'categories',
             'tags',
+            'statuses',
         ]);
 });
 
@@ -186,6 +191,7 @@ test('can edit post', function (): void {
         'category_id' => $CategoryId,
         'description' => 'this is the description',
         'content' => 'this is the content',
+        'status' => PostStatus::Published->value,
         'tags' => ['Eloquent'],
     ])
         ->assertRedirect(route('posts.index', ['sortBy' => 'title', 'direction' => 'asc']))

--- a/tests/Unit/Enums/PostStatusTest.php
+++ b/tests/Unit/Enums/PostStatusTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostStatus;
+
+it('returns the correct label for Draft', function (): void {
+    $status = PostStatus::Draft;
+    $label = $status->label();
+
+    expect($label)->toBe(__('posts.status.Draft'));
+});
+
+it('returns the correct label for Published', function (): void {
+    $status = PostStatus::Published;
+    $label = $status->label();
+
+    expect($label)->toBe(__('posts.status.Published'));
+});
+
+it('returns the correct color for Draft', function (): void {
+    $status = PostStatus::Draft;
+    $color = $status->color();
+
+    expect($color)->toBe('bg-yellow-500');
+});
+
+it('returns the correct color for Published', function (): void {
+    $status = PostStatus::Published;
+    $color = $status->color();
+
+    expect($color)->toBe('bg-green-500');
+});
+
+it('returns the correct badge color for Draft', function (): void {
+    $status = PostStatus::Draft;
+    $badgeColor = $status->badgeColor();
+
+    expect($badgeColor)->toBe('yellow');
+});
+
+it('returns the correct badge color for Published', function (): void {
+    $status = PostStatus::Published;
+    $badgeColor = $status->badgeColor();
+
+    expect($badgeColor)->toBe('green');
+});
+
+it('returns the correct badge color', function (string $value, string $expected): void {
+    expect(PostStatus::tryFrom($value)?->badgeColor())->toBe($expected);
+})
+    ->with([
+        PostStatus::Draft->name => [
+            'value' => PostStatus::Draft->value,
+            'expected' => 'yellow',
+        ],
+        PostStatus::Published->name => [
+            'value' => PostStatus::Published->value,
+            'expected' => 'green',
+        ],
+    ]);


### PR DESCRIPTION
We adds a new "status" field to posts, allowing them to be marked as either **Draft** or **Published**.

<img width="403" height="286" alt="Adding status to basic crud" src="https://github.com/user-attachments/assets/a7e8f660-e0ef-430f-a66f-69efad35415b" />
